### PR TITLE
Don't throw an ErrorException if exif data is corrupt

### DIFF
--- a/src/Transit/ErrorHandler.php
+++ b/src/Transit/ErrorHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Transit;
+
+class ErrorHandler
+{
+    /**
+     * Taken from Symphony
+     * https://github.com/symfony/error-handler/blob/a6c529f2970a/ErrorHandler.php#L158-L182
+     * 
+     * Calls a function and turns any PHP error into \ErrorException.
+     *
+     * @return mixed What $function(...$arguments) returns
+     *
+     * @throws \ErrorException When $function(...$arguments) triggers a PHP error
+     */
+    public static function call(callable $function, ...$arguments)
+    {
+        set_error_handler(static function (int $type, string $message, string $file, int $line) {
+            if (__FILE__ === $file) {
+                $trace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 3);
+                $file = $trace[2]['file'] ?? $file;
+                $line = $trace[2]['line'] ?? $line;
+            }
+
+            throw new \ErrorException($message, 0, $type, $file, $line);
+        });
+
+        try {
+            return $function(...$arguments);
+        } finally {
+            restore_error_handler();
+        }
+    }
+}

--- a/src/Transit/File.php
+++ b/src/Transit/File.php
@@ -10,6 +10,7 @@ namespace Transit;
 use Transit\Exception\IoException;
 use \InvalidArgumentException;
 use \Closure;
+use ErrorException;
 
 /**
  * Handles the management of a single file on the file system.
@@ -218,6 +219,17 @@ class File {
 
             return $exif;
         });
+    }
+
+    private function getExifFromFile(File $file): ?array
+    {
+      $path = $file->path();
+
+      try {
+        return ErrorHandler::call(fn() => exif_read_data($path));
+      } catch (ErrorException $e) {
+        return null;
+      }
     }
 
     private function normalizeCoords($coord): int {


### PR DESCRIPTION
Instead continue to process the image. The EXIF block is only needed to fix the orientation, which in most cases is fine anyway.